### PR TITLE
set enable without animation while initialization

### DIFF
--- a/JYRefreshController/Source/JYPullToLoadMoreController.m
+++ b/JYRefreshController/Source/JYPullToLoadMoreController.m
@@ -52,7 +52,7 @@
                      context:NULL];
 
     [self setCustomView:[self defalutRefreshView]];
-    self.enable = YES;
+    [self setEnable:YES withAnimation:NO];
   }
   return self;
 }
@@ -74,6 +74,11 @@
 
 - (void)setEnable:(BOOL)enable
 {
+  [self setEnable:enable withAnimation:YES];
+}
+
+- (void)setEnable:(BOOL)enable withAnimation:(BOOL)animated
+{
   if (_enable == enable) { // no change
     return;
   }
@@ -90,7 +95,7 @@
     contentInset.bottom = self.originalContentInsetBottom;
   }
 
-  [UIView animateWithDuration:JYLoadMoreViewAnimationDuration
+  [UIView animateWithDuration:(animated ? JYLoadMoreViewAnimationDuration : 0)
                         delay:0
                       options:UIViewAnimationOptionAllowUserInteraction | UIViewAnimationOptionBeginFromCurrentState
                    animations:^{


### PR DESCRIPTION
如果在 `viewDidLoad` 中创建 `JYPullToLoadMoreController`，默认设置 `enable` 为 `YES` 时，带着的动画会把 UIScrollView 的改动也带上，也就是第一次加载 UITableViewCell 或者 UICollectionViewCell 时就会带着动画效果。这里改为设置初始值时不带动画。