### PR TITLE
load more: make setEnable:withAnimation: public

### DIFF
--- a/JYRefreshController/Source/JYPullToLoadMoreController.h
+++ b/JYRefreshController/Source/JYPullToLoadMoreController.h
@@ -23,6 +23,8 @@ typedef NS_ENUM(NSUInteger, JYLoadMoreState)
 
 @property (nonatomic, assign) BOOL enable;
 
+- (void)setEnable:(BOOL)enable withAnimation:(BOOL)animated;
+
 /**
  *  Set to NO, if need user dragging to trigger load more action. Default is YES.
  */


### PR DESCRIPTION
把 `setEnable:withAnimation:` 暴露出来。

有个问题：为什么 pull to refresh 组件里没有「是否以动画的方式启用」这个功能，而 pull to load more 有？